### PR TITLE
AuthorisationFilter passing through 401, 403 auth responses

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/auth/microservice/connectors/AuthConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/play/auth/microservice/connectors/AuthConnector.scala
@@ -80,7 +80,7 @@ case class AuthRequestParameters(levelOfAssurance: String,
   }
 }
 
-trait AuthorisationResult
+sealed trait AuthorisationResult
 
 case object NotAuthenticated extends AuthorisationResult
 

--- a/src/main/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilter.scala
@@ -17,13 +17,14 @@
 package uk.gov.hmrc.play.auth.microservice.filters
 
 import play.api.Routes
-import play.api.mvc.{Filter, Headers, RequestHeader, Result}
+import play.api.mvc._
 import uk.gov.hmrc.play.audit.http.HeaderCarrier
 import uk.gov.hmrc.play.auth.controllers.AuthConfig
 import uk.gov.hmrc.play.auth.microservice.connectors._
+import uk.gov.hmrc.play.http.HeaderNames
 import uk.gov.hmrc.play.http.logging.LoggingDetails
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
-import uk.gov.hmrc.play.http.{HeaderNames, UnauthorizedException, ForbiddenException}
+
 import scala.concurrent.Future
 
 trait AuthorisationFilter extends Filter {
@@ -36,37 +37,41 @@ trait AuthorisationFilter extends Filter {
     implicit val hc = HeaderCarrier.fromHeaders(rh.headers)
 
     authConfig(rh) match {
-      case Some(authConfig) => isAuthorised(rh, authConfig).flatMap {
-        case Authorised(true) => next(appendSurrogateHeader(rh))
-        case Authorised(_)    => next(rh)
-        case _ : NotAuthenticated => throw new UnauthorizedException(s"Authorisation refused for access to ${rh.method} ${rh.uri}")
-        case Forbidden        => throw new ForbiddenException(s"Authorisation refused for access to ${rh.method} ${rh.uri}")
+      case Some(authConfig) => isAuthorised(rh, authConfig).flatMap { result =>
+        result.header.status match {
+          case 200 => next(appendSurrogateHeader(rh, result))
+          case 401 | 403 => Future.successful(result)
+          case _ => Future.successful(Results.Unauthorized)
+        }
       }
       case _ => next(rh)
     }
   }
 
-  private def appendSurrogateHeader(rh: RequestHeader): RequestHeader = {
+  private def appendSurrogateHeader(rh: RequestHeader, response : Result ): RequestHeader = {
     val existingHeaders = rh.headers.toMap
     val newHeaders = new Headers {
-      val data: Seq[(String, Seq[String])] = existingHeaders.toSeq ++ Seq(HeaderNames.surrogate -> Seq("true"))
+      val data: Seq[(String, Seq[String])] =
+        response.header.headers.get(HeaderNames.surrogate).fold(existingHeaders.toSeq) {
+          case "true" => existingHeaders.toSeq ++ Seq(HeaderNames.surrogate -> Seq("true"))
+          case _ => existingHeaders.toSeq
+        }
     }
-
     rh.copy(headers = newHeaders)
   }
 
   private implicit def sequence[T](of: Option[Future[T]])(implicit ld: LoggingDetails): Future[Option[T]] =
     of.map(f => f.map(Option(_))).getOrElse(Future.successful(None))
 
-  private def isAuthorised(rh: RequestHeader, authConfig: AuthConfig)(implicit hc: HeaderCarrier): Future[AuthorisationResult] = {
-    val result: Future[Option[AuthorisationResult]] =
+  private def isAuthorised(rh: RequestHeader, authConfig: AuthConfig)(implicit hc: HeaderCarrier): Future[Result] = {
+    val result: Future[Option[Result]] =
       for {
         verb <- rh.tags.get(Routes.ROUTE_VERB).map(HttpVerb)
         resource <- extractResource(rh.path, verb, authConfig)
 
       } yield authConnector.authorise(resource, AuthRequestParameters(authConfig.levelOfAssurance.toString,authConfig.agentRole, authConfig.delegatedAuthRule))
 
-    result.map(_.getOrElse(NotAuthenticated()))
+    result.map(_.getOrElse(Results.Unauthorized))
   }
 
   def extractResource(pathString: String, verb: HttpVerb, authConfig: AuthConfig): Option[ResourceToAuthorise] =

--- a/src/main/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilter.scala
@@ -39,7 +39,7 @@ trait AuthorisationFilter extends Filter {
       case Some(authConfig) => isAuthorised(rh, authConfig).flatMap {
         case Authorised(true) => next(appendSurrogateHeader(rh))
         case Authorised(_)    => next(rh)
-        case NotAuthenticated => throw new UnauthorizedException(s"Authorisation refused for access to ${rh.method} ${rh.uri}")
+        case _ : NotAuthenticated => throw new UnauthorizedException(s"Authorisation refused for access to ${rh.method} ${rh.uri}")
         case Forbidden        => throw new ForbiddenException(s"Authorisation refused for access to ${rh.method} ${rh.uri}")
       }
       case _ => next(rh)
@@ -66,7 +66,7 @@ trait AuthorisationFilter extends Filter {
 
       } yield authConnector.authorise(resource, AuthRequestParameters(authConfig.levelOfAssurance.toString,authConfig.agentRole, authConfig.delegatedAuthRule))
 
-    result.map(_.getOrElse(NotAuthenticated))
+    result.map(_.getOrElse(NotAuthenticated()))
   }
 
   def extractResource(pathString: String, verb: HttpVerb, authConfig: AuthConfig): Option[ResourceToAuthorise] =

--- a/src/main/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilter.scala
@@ -23,8 +23,7 @@ import uk.gov.hmrc.play.auth.controllers.AuthConfig
 import uk.gov.hmrc.play.auth.microservice.connectors._
 import uk.gov.hmrc.play.http.logging.LoggingDetails
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
-import uk.gov.hmrc.play.http.{HeaderNames, UnauthorizedException}
-
+import uk.gov.hmrc.play.http.{HeaderNames, UnauthorizedException, ForbiddenException}
 import scala.concurrent.Future
 
 trait AuthorisationFilter extends Filter {
@@ -39,8 +38,9 @@ trait AuthorisationFilter extends Filter {
     authConfig(rh) match {
       case Some(authConfig) => isAuthorised(rh, authConfig).flatMap {
         case Authorised(true) => next(appendSurrogateHeader(rh))
-        case Authorised(_) => next(rh)
-        case _ => throw new UnauthorizedException(s"Authorisation refused for access to ${rh.method} ${rh.uri}")
+        case Authorised(_)    => next(rh)
+        case NotAuthenticated => throw new UnauthorizedException(s"Authorisation refused for access to ${rh.method} ${rh.uri}")
+        case Forbidden        => throw new ForbiddenException(s"Authorisation refused for access to ${rh.method} ${rh.uri}")
       }
       case _ => next(rh)
     }

--- a/src/test/scala/uk/gov/hmrc/play/auth/microservice/connectors/AuthConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/auth/microservice/connectors/AuthConnectorSpec.scala
@@ -16,59 +16,21 @@
 
 package uk.gov.hmrc.play.auth.microservice.connectors
 
+import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{Matchers, WordSpecLike}
-import play.api.libs.json.JsValue
-import play.api.libs.ws.{WSCookie, WSResponse}
+import play.api.libs.ws.WSResponse
+import play.api.test.Helpers._
 import uk.gov.hmrc.play.audit.http.HeaderCarrier
-import uk.gov.hmrc.play.http.{HeaderNames, HttpResponse}
-import org.mockito.Mockito._
 
 import scala.concurrent.Future
-import scala.xml.Elem
 
 class AuthConnectorSpec extends WordSpecLike with Matchers with MockitoSugar with ScalaFutures {
   val stubAuthConnector = new AuthConnector {
     override def authBaseUrl = ???
 
     override protected def callAuth(url: String)(implicit hc: HeaderCarrier): Future[WSResponse] = ???
-  }
-
-  "AuthConnector.isSurrogate" should {
-
-    case class StubWSResponse(headerValToReturn: Option[String]) extends WSResponse {
-      override def allHeaders: Map[String, Seq[String]] = ???
-      override def statusText: String = ???
-      override def underlying[T]: T = ???
-      override def xml: Elem = ???
-      override def body: String = ???
-      override def header(key: String): Option[String] = headerValToReturn
-      override def cookie(name: String): Option[WSCookie] = ???
-      override def cookies: Seq[WSCookie] = ???
-      override def status: Int = ???
-      override def json: JsValue = ???
-    }
-
-    "return true if the surrogate header contains the string \"true\"" in {
-      stubAuthConnector.isSurrogate(StubWSResponse(Some("true"))) shouldBe true
-    }
-
-    "return false if the surrogate header does not exist" in {
-      stubAuthConnector.isSurrogate(StubWSResponse(None)) shouldBe false
-    }
-
-    "return true if the surrogate header contains the string \"false\"" in {
-      stubAuthConnector.isSurrogate(StubWSResponse(Some("false"))) shouldBe false
-    }
-
-    "return false if the surrogate header is empty" in {
-      stubAuthConnector.isSurrogate(StubWSResponse(Some(""))) shouldBe false
-    }
-
-    "return false if the surrogate header cannot be mapped to a boolean" in {
-      stubAuthConnector.isSurrogate(StubWSResponse(Some("invalid"))) shouldBe false
-    }
   }
 
 
@@ -145,52 +107,12 @@ class AuthConnectorSpec extends WordSpecLike with Matchers with MockitoSugar wit
       authConnector.calledUrl shouldBe Some(s"authBase/authorise/read/foo?levelOfAssurance=$loa")
     }
 
-    "return Authorised(true) when auth response is 200 and request header contains surrogate " in new SetupForAuthorisation {
+    "return auth result with the headers" in new SetupForAuthorisation {
       when(authResponse.status).thenReturn(200)
-      when(authResponse.header(HeaderNames.surrogate)).thenReturn(Some("true"))
-
-      val result = authConnector.authorise(resourceToAuthorise, AuthRequestParameters(loa))(new HeaderCarrier).futureValue
-      result shouldBe Authorised(true)
-    }
-
-    "return Authorised(true) when auth response is 200 and request header does not contain surrogate" in new SetupForAuthorisation {
-      when(authResponse.status).thenReturn(200)
-      when(authResponse.header(HeaderNames.surrogate)).thenReturn(None)
-
-      val result = authConnector.authorise(resourceToAuthorise, AuthRequestParameters(loa))(new HeaderCarrier).futureValue
-      result shouldBe Authorised(false)
-    }
-
-    "return NotAuthenticated when auth response is 401" in new SetupForAuthorisation {
-      when(authResponse.status).thenReturn(401)
-      when(authResponse.header("WWW-Authenticate")).thenReturn(None)
-
-      val result = authConnector.authorise(resourceToAuthorise, AuthRequestParameters(loa))(new HeaderCarrier).futureValue
-      result shouldBe NotAuthenticated()
-    }
-
-    "return Forbidden when auth response is 403" in new SetupForAuthorisation {
-      when(authResponse.status).thenReturn(403)
-
-      val result = authConnector.authorise(resourceToAuthorise, AuthRequestParameters(loa))(new HeaderCarrier).futureValue
-      result shouldBe Forbidden
-
-    }
-
-    "return NotAuthenticated when auth response is any other status code" in new SetupForAuthorisation {
-      when(authResponse.status).thenReturn(500)
-
-      val result = authConnector.authorise(resourceToAuthorise, AuthRequestParameters(loa))(new HeaderCarrier).futureValue
-      result shouldBe NotAuthenticated()
-
-    }
-
-    "return NotAuthenticated with the failure details" in new SetupForAuthorisation {
-      when(authResponse.status).thenReturn(401)
-      when(authResponse.header("WWW-Authenticate")).thenReturn(Some("""Bearer realm="example", error="invalid_token", error_description="The access token expired""""))
-
-      val result = authConnector.authorise(resourceToAuthorise, AuthRequestParameters(loa))(new HeaderCarrier).futureValue
-      result shouldBe NotAuthenticated(Some("invalid_token"), Some("The access token expired"))
+      when(authResponse.allHeaders).thenReturn(Map("a-header" -> Seq("a-value")))
+      val result = authConnector.authorise(resourceToAuthorise, AuthRequestParameters(loa))(new HeaderCarrier)
+      status(result) shouldBe 200
+      result.futureValue.header.headers("a-header") shouldBe "a-value"
     }
   }
 

--- a/src/test/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilterSpec.scala
@@ -70,8 +70,8 @@ class AuthorisationFilterSpec extends WordSpecLike with MatchersResults with Moc
       captor.getValue().levelOfAssurance shouldBe levelOfAssurance.toString
     }
 
-    "throw UnauthorizedException if auth returns NotAuthenticated" in new Setup {
-      val result = filterRequest(Future.successful(NotAuthenticated))
+    "return 401 if auth returns NotAuthenticated" in new Setup {
+      val result = filterRequest(Future.successful(NotAuthenticated()))
       result.failed.futureValue shouldBe a [UnauthorizedException]
     }
 

--- a/src/test/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilterSpec.scala
@@ -23,23 +23,20 @@ import org.scalatest.mock.MockitoSugar
 import org.scalatest.{Matchers => MatchersResults, WordSpecLike}
 import play.api.Routes
 import play.api.mvc.Results._
-import play.api.mvc.{AnyContentAsEmpty, RequestHeader, Result}
+import play.api.mvc.{AnyContentAsEmpty, RequestHeader, Result, Results}
+import play.api.test.Helpers._
 import play.api.test.{FakeHeaders, FakeRequest}
 import uk.gov.hmrc.play.auth.controllers.{AuthConfig, LevelOfAssurance}
-import uk.gov.hmrc.play.auth.microservice.connectors.{Authorised, AuthConnector, AuthRequestParameters, AuthorisationResult}
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import uk.gov.hmrc.play.auth.microservice.connectors.{Authorised, NotAuthenticated, Forbidden}
-import uk.gov.hmrc.play.http.{UnauthorizedException, ForbiddenException}
+import uk.gov.hmrc.play.auth.microservice.connectors.{AuthConnector, AuthRequestParameters}
+import uk.gov.hmrc.play.http.HeaderNames
 
+import scala.concurrent.Future
 
 class AuthorisationFilterSpec extends WordSpecLike with MatchersResults with MockitoSugar with ScalaFutures {
 
 
   private trait Setup {
-    import akka.util.Timeout
-    implicit val timeout = Timeout(3 seconds)
-      
+
     val levelOfAssurance = LevelOfAssurance.LOA_1_5
     val configWithLoa = AuthConfig(levelOfAssurance = levelOfAssurance)
     val authConnectorMock = mock[AuthConnector]
@@ -50,39 +47,66 @@ class AuthorisationFilterSpec extends WordSpecLike with MatchersResults with Moc
       override def authConfig(rh: RequestHeader): Option[AuthConfig] = Some(configWithLoa)
     }
     
-    def filterRequest(connectorResult: Future[AuthorisationResult]): Future[Result] = {
+    def filterRequest(connectorResult: Future[Result], isSurrogate: Boolean= false): Future[Result] = {
       when(authConnectorMock.authorise(Matchers.any(), Matchers.any())(Matchers.any())).thenReturn(connectorResult)
       val req = FakeRequest("GET", "/myregime/myId", FakeHeaders(), AnyContentAsEmpty, tags = Map(Routes.ROUTE_VERB-> "GET"))
 
-      filter((next: RequestHeader) => Future.successful(Ok("All is good")))(req)
+      filter((next: RequestHeader) => {
+        val isSurrogate = next.headers.get(HeaderNames.surrogate) == Some("true")
+        Future.successful(Ok(if (isSurrogate) "All is surrogate" else "All is good"))
+      })(req)
     }
   }
 
   "AuthorisationFilter" should {
 
     "add the levelOfAssurance when calling auth" in new Setup {
-      val result = filterRequest(Future.successful(Authorised(false)))
-      play.api.test.Helpers.status(result) shouldBe 200
-      play.api.test.Helpers.contentAsString(result) shouldBe "All is good"
+      val result = filterRequest(Future.successful(Results.Ok))
+      status(result) shouldBe 200
+      contentAsString(result) shouldBe "All is good"
 
       val captor = ArgumentCaptor.forClass(classOf[AuthRequestParameters])
       verify(authConnectorMock).authorise(Matchers.any(),captor.capture())(Matchers.any())
       captor.getValue().levelOfAssurance shouldBe levelOfAssurance.toString
     }
 
-    "return 401 if auth returns NotAuthenticated" in new Setup {
-      val result = filterRequest(Future.successful(NotAuthenticated()))
-      result.failed.futureValue shouldBe a [UnauthorizedException]
+    "return 401 if auth returns 401" in new Setup {
+      val result = filterRequest(Future.successful(Results.Unauthorized))
+      status(result) shouldBe 401
     }
 
-    "throw ForbiddenException if auth returns Forbidden" in new Setup {
+    "keep all headers if auth returns 401" in new Setup {
+      val result = filterRequest(Future.successful(Results.Unauthorized.withHeaders("WWW-Authenticated" -> "xxx")))
+      status(result) shouldBe 401
+      header("WWW-Authenticated", result) shouldBe Some("xxx")
+    }
+
+    "return 403 if auth returns 403" in new Setup {
       val result = filterRequest(Future.successful(Forbidden))
-      result.failed.futureValue shouldBe a [ForbiddenException]
+      status(result) shouldBe 403
     }
 
-    "let the request though if auth returns Authentiated(_)" in new Setup {
-      val result = filterRequest(Future.successful(Authorised(false)))
-      play.api.test.Helpers.status(result) shouldBe 200
+    "return 401 if auth returns any other error" in new Setup {
+      val result = filterRequest(Future.successful(Results.InternalServerError))
+      status(result) shouldBe 401
+    }
+
+    "let the request though if auth returns 200" in new Setup {
+      val result = filterRequest(Future.successful(Results.Ok))
+      status(result) shouldBe 200
+      contentAsString(result) shouldBe "All is good"
+    }
+
+    "add surrogate header to request if auth responds with that header set to true" in new Setup {
+      val result = filterRequest(Future.successful(Results.Ok.withHeaders(HeaderNames.surrogate -> "true")))
+      status(result) shouldBe 200
+      contentAsString(result) shouldBe "All is surrogate"
+    }
+
+    "not add surrogate header to request if auth responds with that header set to any other value" in new Setup {
+      val result = filterRequest(Future.successful(Results.Ok.withHeaders(HeaderNames.surrogate -> "foo")))
+      status(result) shouldBe 200
+      contentAsString(result) shouldBe "All is good"
     }
   }
 }


### PR DESCRIPTION
Simplified and expanded AuthorisationFilter:
- Now handles 403 responses from auth
- Now passes through headers from auth (needed for additional info in 401 responses)
- Removed a lot of indirection in the implementation (e.g. temporary models)

The outside behaviour of the filter has changed. It does no longer throw Exceptions for unauthorized users, but instead builds the full HTTP response.
