### PR TITLE
PLATOPS-1619: upgrade to Play 2.5.19

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -7,7 +7,6 @@ import uk.gov.hmrc.versioning.SbtGitVersioning
 object HmrcBuild extends Build {
 
   import BuildDependencies._
-  import uk.gov.hmrc.DefaultBuildSettings._
 
   val appName = "play-authorisation"
 
@@ -18,7 +17,7 @@ object HmrcBuild extends Build {
     .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning)
     .settings(
       name := appName,
-      scalaVersion := "2.11.7",
+      scalaVersion := "2.11.12",
       libraryDependencies ++= Seq(
         Compile.playFramework,
         Compile.httpVerbs,
@@ -34,12 +33,11 @@ object HmrcBuild extends Build {
 
 private object BuildDependencies {
 
-  import play.sbt.PlayImport._
   import play.core.PlayVersion
 
   object Compile {
     val playFramework = "com.typesafe.play" %% "play" % PlayVersion.current % "provided"
-    val httpVerbs = "uk.gov.hmrc" %% "http-verbs-play-25" % "0.6.0"
+    val httpVerbs = "uk.gov.hmrc" %% "http-verbs" % "8.10.0-play-25"
     val ficus = "net.ceedubs" %% "ficus" % "1.1.1"
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,4 +7,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.4.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.9.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")

--- a/src/main/scala/uk/gov/hmrc/play/auth/controllers/AuthConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/play/auth/controllers/AuthConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/auth/microservice/AuthorisationChecks.scala
+++ b/src/main/scala/uk/gov/hmrc/play/auth/microservice/AuthorisationChecks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/auth/microservice/connectors/AuthConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/play/auth/microservice/connectors/AuthConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/auth/controllers/AuthConfigSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/auth/controllers/AuthConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/auth/microservice/AuthorisationChecksSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/auth/microservice/AuthorisationChecksSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/auth/microservice/connectors/AuthConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/auth/microservice/connectors/AuthConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/auth/microservice/filters/AuthorisationFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
We have had to update all the libraries on the platform to use Play 2.5.19 to address a security vulnerability with a version of logback that is included in play (< 2.5.14) which is fixed in play 2.5.19.  